### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 springboot脚手架，集成jpa freemarker dubbo security为一体,使用不到的可以将对应的maven依赖删除即可.
 
 
-#开发工具
+# 开发工具
 项目使用了lombok，so 用idea开发的小伙伴请安装lombok插件，不然会提示报错
 
-#目录结构
+# 目录结构
 |____src                                        <br>                                       
 | |____main                                     <br>
 | | |____java                                   <br>
@@ -46,7 +46,7 @@ springboot脚手架，集成jpa freemarker dubbo security为一体,使用不到�
 工程，系统将自动载入dubbo.properties相关配置
 
 
-#运行方式
+# 运行方式
 
 1. 本地开发：执行com.tuicr.scaffold.Bootstrap的main即可运行服务端,相关容器配置项请修改application.yml <br>
 2. 生产部署：个人比较倾向于打成jar进行部署,运行方式java -jar target/xxxxxx-0.0.1-SNAPSHOT.jar <br>
@@ -55,7 +55,7 @@ springboot脚手架，集成jpa freemarker dubbo security为一体,使用不到�
 
 
 
-#web-server
+# web-server
 适用于web项目,加入了验证码的机制<br>
 ApplicationStartUp项目启动完成调用<br>
 CommonConfiguration配置spring最基本的配置<br>
@@ -65,7 +65,7 @@ DubboAutoConfiguration用注解的方式配置dubbo<br>
 项目配置文件加载统一配置在Bootstrap类中,暂时只放置了dbconfig.properties / secure.properties
 
 
-#restful-server
+# restful-server
 
 api服务端脚手架
 拦截/api/**请求,通过header验证请求的合法性,(类似JWT)<br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
